### PR TITLE
Fix `npimage.show()` for segmentation data_type

### DIFF
--- a/npimage/imageio.py
+++ b/npimage/imageio.py
@@ -394,7 +394,7 @@ def show(data,
             data = load(data)
 
     if data_type == 'segmentation':
-        data = utils.assign_random_colors(data, seed=kwargs.get('seed', None))
+        data = operations.assign_random_colors(data, seed=kwargs.get('seed', None))
 
     if (not data.ndim == 2) and not (data.ndim == 3 and utils.find_channel_axis(data) is not None):
         m = ('Data must have shape (y, x) for grayscale, '


### PR DESCRIPTION
This PR will fix `AttributeError: module 'npimage.utils' has no attribute 'assign_random_colors'` when `npimage.show(data_type = 'segmentation')` is called.

Here is my error log:
```py
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
Cell In[11], line 2
      1 import npimage
----> 2 npimage.show(labels_out, mode="mpl", data_type = 'segmentation')

File ~\Workstation2025\Aimbot\aimbot\.venv\lib\site-packages\npimage\imageio.py:397, in show(data, dim_order, data_type, mode, convert_to_8bit, convert_kwargs, channel_axis, **kwargs)
    394         data = load(data)
    396 if data_type == 'segmentation':
--> 397     data = utils.assign_random_colors(data, seed=kwargs.get('seed', None))
    399 if (not data.ndim == 2) and not (data.ndim == 3 and utils.find_channel_axis(data) is not None):
    400     m = ('Data must have shape (y, x) for grayscale, '
    401          '(y, x, 3) for RGB, or (y, x, 4) for RGBA but had '
    402          f'shape {data.shape}')

AttributeError: module 'npimage.utils' has no attribute 'assign_random_colors'
```